### PR TITLE
Refactor lists component

### DIFF
--- a/src/applications/AdminDashboard/routes.js
+++ b/src/applications/AdminDashboard/routes.js
@@ -55,12 +55,6 @@ const routes = [
     name: 'Settings',
     component: Settings,
     exact: false
-  },
-  {
-    path: '/Devices',
-    name: 'Devices',
-    component: Devices,
-    exact: false
   }
 ]
 

--- a/src/applications/AdminDashboard/routes.js
+++ b/src/applications/AdminDashboard/routes.js
@@ -6,6 +6,7 @@ import Applications from '../../containers/Applications'
 import Users from '../../containers/Users'
 import About from '../../containers/About'
 import Settings from '../../containers/Settings'
+import Devices from '../../containers/Devices'
 
 const routes = [
   {
@@ -51,9 +52,15 @@ const routes = [
     exact: false
   },
   {
-    path: '/settings',
+    path: '/Settings',
     name: 'Settings',
     component: Settings,
+    exact: false
+  },
+  {
+    path: '/Devices',
+    name: 'Devices',
+    component: Devices,
     exact: false
   }
 ]

--- a/src/applications/AdminDashboard/routes.js
+++ b/src/applications/AdminDashboard/routes.js
@@ -6,7 +6,6 @@ import Applications from '../../containers/Applications'
 import Users from '../../containers/Users'
 import About from '../../containers/About'
 import Settings from '../../containers/Settings'
-import Devices from '../../containers/Devices'
 
 const routes = [
   {

--- a/src/assets/styles/architecture/1_level_settings/_colors.scss
+++ b/src/assets/styles/architecture/1_level_settings/_colors.scss
@@ -17,7 +17,7 @@ $info: #00BCD4;
 
 // Colors to delete
 
-$text-detail-color: darken($color-2-primary, 5);
+$text-detail-color: grey;
 $border-ligth-color: lighten($color-2-primary, 5);
 $app-color: $color-1-primary;
 $white-color: $color-2-primary;

--- a/src/assets/styles/architecture/5_level_components/_listPane.scss
+++ b/src/assets/styles/architecture/5_level_components/_listPane.scss
@@ -2,13 +2,17 @@
 
     .contentListView {
 
-        .win-surface {
-            margin-top: 0;
+    .win-listlayout {
+        margin-top: 0;
+    }
+
+    .win-surface {
+            margin-top: 0 !important;
             white-space: nowrap;
         }
 
         .win-container {
-            margin: 0;
+            margin: 0 !important;
         }
 
         .win-item {
@@ -53,7 +57,7 @@
         .win-groupheadercontainer {
             width: 32px;
             height: 32px;
-            margin-top: 7px;
+            margin-top: 7px !important;
             margin-bottom: 10px;
             margin-left: 12px;
         }
@@ -64,7 +68,7 @@
             height: 32px;
             padding: 0;
             background-color: $app-color;
-            color: $white-color;
+            color: $color-2-primary;
             text-align: center;
             line-height: 32px;
         } 
@@ -73,7 +77,7 @@
 }
 
 .listToolBar .win-toolbar-actionarea {
-    background-color: $white-color;
+    background-color: $color-2-primary;
 }
 
 .win-commandingsurface .win-commandingsurface-actionarea {

--- a/src/assets/styles/architecture/5_level_components/_listPane.scss
+++ b/src/assets/styles/architecture/5_level_components/_listPane.scss
@@ -1,0 +1,81 @@
+.listPane {
+
+    .contentListView {
+
+        .win-surface {
+            margin-top: 0;
+            white-space: nowrap;
+        }
+
+        .win-container {
+            margin: 0;
+        }
+
+        .win-item {
+            padding-top: 8px;
+            padding-bottom: 8px;
+            width: calc(100% - 24px);
+            padding-left: 12px;
+
+            .contentPicture {
+                width: 42px;
+                height: 42px;
+                background-size: cover;
+                -webkit-border-radius: 42px;
+                -moz-border-radius: 42px;
+                border-radius: 42px;
+                display: inline-block;
+                vertical-align: top;
+                margin-right: 8px;
+            }
+
+            .name, .detail {
+                vertical-align: middle;
+                width: 240px;
+                $white-color-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                font-weight: 400;
+            }
+
+            .name {
+                font-size: 18px;
+                line-height: 22px;
+            }
+
+            .detail {
+                color: $text-detail-color;
+                font-size: 13px;
+                line-height: 16px;
+            }
+        }
+        
+        .win-groupheadercontainer {
+            width: 32px;
+            height: 32px;
+            margin-top: 7px;
+            margin-bottom: 10px;
+            margin-left: 12px;
+        }
+
+        .win-groupheader {
+            font-size: 15px;
+            width: 32px;
+            height: 32px;
+            padding: 0;
+            background-color: $app-color;
+            color: $white-color;
+            text-align: center;
+            line-height: 32px;
+        } 
+
+    }
+}
+
+.listToolBar .win-toolbar-actionarea {
+    background-color: $white-color;
+}
+
+.win-commandingsurface .win-commandingsurface-actionarea {
+    justify-content: space-around !important;
+}

--- a/src/assets/styles/architecture/5_level_components/_listpane.scss
+++ b/src/assets/styles/architecture/5_level_components/_listpane.scss
@@ -2,13 +2,17 @@
 
     .contentListView {
 
-        .win-surface {
-            margin-top: 0;
+    .win-listlayout {
+        margin-top: 0;
+    }
+
+    .win-surface {
+            margin-top: 0 !important;
             white-space: nowrap;
         }
 
         .win-container {
-            margin: 0;
+            margin: 0 !important;
         }
 
         .win-item {
@@ -53,7 +57,7 @@
         .win-groupheadercontainer {
             width: 32px;
             height: 32px;
-            margin-top: 7px;
+            margin-top: 7px !important;
             margin-bottom: 10px;
             margin-left: 12px;
         }
@@ -64,7 +68,7 @@
             height: 32px;
             padding: 0;
             background-color: $app-color;
-            color: $white-color;
+            color: $color-2-primary;
             text-align: center;
             line-height: 32px;
         } 
@@ -73,7 +77,7 @@
 }
 
 .listToolBar .win-toolbar-actionarea {
-    background-color: $white-color;
+    background-color: $color-2-primary;
 }
 
 .win-commandingsurface .win-commandingsurface-actionarea {

--- a/src/assets/styles/architecture/5_level_components/_listpane.scss
+++ b/src/assets/styles/architecture/5_level_components/_listpane.scss
@@ -1,79 +1,81 @@
 .listPane {
 
-  .listToolBar {
-    .win-commandingsurface .win-commandingsurface-actionarea .win-commandingsurface-overflowbutton {
-      width: 48px
-    }
-  }
+    .contentListView {
 
-  .contentListView {
-    height: calc(100vh - 98px);
-    background-color: #e6e6e6;
-
-    .win-surface {
-        margin-top: 0;
-    }
-
-    .win-container {
-        margin: 0;
-    }
-
-    .win-item {
-        padding-top: 8px;
-        padding-bottom: 8px;
-        width: calc(100% - 24px);
-        padding-left: 12px;
-
-        .contentPicture {
-            width: 42px;
-            height: 42px;
-            background-size: cover;
-            -webkit-border-radius: 42px;
-            -moz-border-radius: 42px;
-            border-radius: 42px;
-            display: inline-block;
-            vertical-align: top;
-            margin-right: 8px;
+        .win-surface {
+            margin-top: 0;
+            white-space: nowrap;
         }
 
-        .name, .detail {
-            vertical-align: middle;
-            width: 240px;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            font-weight: 400;
+        .win-container {
+            margin: 0;
         }
 
-        .name {
-            font-size: 18px;
-            line-height: 22px;
+        .win-item {
+            padding-top: 8px;
+            padding-bottom: 8px;
+            width: calc(100% - 24px);
+            padding-left: 12px;
+
+            .contentPicture {
+                width: 42px;
+                height: 42px;
+                background-size: cover;
+                -webkit-border-radius: 42px;
+                -moz-border-radius: 42px;
+                border-radius: 42px;
+                display: inline-block;
+                vertical-align: top;
+                margin-right: 8px;
+            }
+
+            .name, .detail {
+                vertical-align: middle;
+                width: 240px;
+                $white-color-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                font-weight: 400;
+            }
+
+            .name {
+                font-size: 18px;
+                line-height: 22px;
+            }
+
+            .detail {
+                color: $text-detail-color;
+                font-size: 13px;
+                line-height: 16px;
+            }
+        }
+        
+        .win-groupheadercontainer {
+            width: 32px;
+            height: 32px;
+            margin-top: 7px;
+            margin-bottom: 10px;
+            margin-left: 12px;
         }
 
-        .detail {
-            color: $splitview-color-fonts;
-            font-size: 13px;
-            line-height: 16px;
-        }
+        .win-groupheader {
+            font-size: 15px;
+            width: 32px;
+            height: 32px;
+            padding: 0;
+            background-color: $app-color;
+            color: $white-color;
+            text-align: center;
+            line-height: 32px;
+        } 
+
     }
-    
-    .win-groupheadercontainer {
-        width: 32px;
-        height: 32px;
-        margin-top: 7px;
-        margin-bottom: 10px;
-        margin-left: 12px;
-    }
+}
 
-    .win-groupheader {
-        font-size: 15px;
-        width: 32px;
-        height: 32px;
-        padding: 0;
-        background-color: $app-color;
-        color: $white-color;
-        text-align: center;
-        line-height: 32px;
-    } 
+.listToolBar .win-toolbar-actionarea {
+    background-color: $white-color;
+}
 
-  }
+.win-commandingsurface .win-commandingsurface-actionarea {
+    justify-content: space-around !important;
 }

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -23,6 +23,7 @@
 @import './architecture/5_level_components/dashboard';
 @import './architecture/5_level_components/title';
 @import './architecture/5_level_components/layout_list_with_navlinks';
+@import './architecture/5_level_components/listPane';
 
 // Without Refactor
 @import './architecture/5_level_components/listpane';

--- a/src/components/GenerateRoutes/index.js
+++ b/src/components/GenerateRoutes/index.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Route } from 'react-router-dom';
+import React from 'react'
+import { Route } from 'react-router-dom'
 
 // TODO: Enable PrivateRoute if route if private
 
@@ -26,4 +26,4 @@ const generateRoutes = ({routes, rootPath, withNotFound}) => {
   return r
 }
 
-export default generateRoutes;
+export default generateRoutes

--- a/src/components/GenerateRoutes/index.js
+++ b/src/components/GenerateRoutes/index.js
@@ -3,7 +3,7 @@ import { Route } from 'react-router-dom'
 
 // TODO: Enable PrivateRoute if route if private
 
-const generateRoutes = ({routes, rootPath, withNotFound}) => {
+const GenerateRoutes = ({routes, rootPath, withNotFound}) => {
   let r = routes.map(({exact, path, component}, i) => {
     return <Route
       exact={exact}
@@ -26,4 +26,4 @@ const generateRoutes = ({routes, rootPath, withNotFound}) => {
   return r
 }
 
-export default generateRoutes
+export default GenerateRoutes

--- a/src/components/IconItemList/index.js
+++ b/src/components/IconItemList/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 export default class IconItemList extends React.Component {
     render() {
-        const image = (this.props.type === 'file' && this.props.image !== '') ? ("images/" + this.props.image) : this.props.image
+        const image = (this.props.type === 'file' && this.props.image !== '') ? ("/images/" + this.props.image) : this.props.image
         let style = {
             backgroundColor: this.props.backgroundColor,
             width: this.props.size,

--- a/src/components/MenuListWinJs/ItemList/About.js
+++ b/src/components/MenuListWinJs/ItemList/About.js
@@ -1,0 +1,11 @@
+import React, { Component } from 'react'
+
+export default class AboutItemList extends Component {
+    render() {
+        return (
+            <div style={{ padding: '14px', width: '100%' }}>
+                {this.props.itemList.title}
+            </div>
+        )
+    }
+}

--- a/src/components/MenuListWinJs/ItemList/Applications.js
+++ b/src/components/MenuListWinJs/ItemList/Applications.js
@@ -1,0 +1,22 @@
+import React, { Component } from 'react'
+import IconItemList from '../../IconItemList'
+
+export default class ApplicationsItemList extends Component {
+    render() {
+        let image = "data:image/png;base64, " + this.props.itemList["PluginFlyvemdmPackage.icon"]
+        return (
+            <div>
+                <IconItemList 
+                    size={42} 
+                    image={image} 
+                    type="base64"
+                    backgroundColor="transparent"
+                />
+                <div style={{ marginLeft: 5, display: 'inline-block' }}>
+                    <div className="name">{this.props.itemList["PluginFlyvemdmPackage.alias"]}</div>
+                    <div className="detail">{this.props.itemList["PluginFlyvemdmPackage.name"]}</div>
+                </div>
+            </div>
+        )
+    }
+}

--- a/src/components/MenuListWinJs/ItemList/Devices.js
+++ b/src/components/MenuListWinJs/ItemList/Devices.js
@@ -1,0 +1,26 @@
+import React, { Component } from 'react'
+import IconItemList from '../../IconItemList'
+
+export default class DevicesItemList extends Component {
+    render() {
+        let imageAgent = this.props.itemList["PluginFlyvemdmAgent.mdm_type"] ? `${this.props.itemList["PluginFlyvemdmAgent.mdm_type"]}.png` : null
+        let iconComponent 
+        
+        if (imageAgent) {
+            iconComponent = <IconItemList image={imageAgent} size={42} backgroundColor="transparent"/>
+        } else {
+            iconComponent = <IconItemList size={42} />
+        }
+        
+        return (
+            <div>
+                {iconComponent}
+                <div style={{ display: 'inline-block'}}>
+                    <div className="name">{this.props.itemList["PluginFlyvemdmAgent.name"]}</div>
+                    <div className="detail">{this.props.itemList["PluginFlyvemdmAgent.PluginFlyvemdmFleet.name"]}</div>
+                    <div className="detail">{this.props.itemList["PluginFlyvemdmAgent.mdm_type"].toUpperCase()}</div>
+                </div>
+            </div>
+        )
+    }
+}

--- a/src/components/MenuListWinJs/ItemList/Files.js
+++ b/src/components/MenuListWinJs/ItemList/Files.js
@@ -1,0 +1,11 @@
+import React, { Component } from 'react'
+
+export default class FilesItemList extends Component {
+    render() {
+        return (
+            <div style={{ display: 'inline-block' }}>
+                <div className="name">{this.props.itemList["PluginFlyvemdmFile.name"]}</div>
+            </div>
+        )
+    }
+}

--- a/src/components/MenuListWinJs/ItemList/Fleets.js
+++ b/src/components/MenuListWinJs/ItemList/Fleets.js
@@ -1,0 +1,11 @@
+import React, { Component } from 'react'
+
+export default class FleetsItemList extends Component {
+    render() {
+        return (
+            <div style={{ display: 'inline-block' }}>
+                <div className="name">{this.props.itemList["PluginFlyvemdmFleet.name"]}</div>
+            </div>
+        )
+    }
+}

--- a/src/components/MenuListWinJs/ItemList/Invitations.js
+++ b/src/components/MenuListWinJs/ItemList/Invitations.js
@@ -1,0 +1,12 @@
+import React, { Component } from 'react'
+
+export default class InvitationsItemList extends Component {
+    render() {
+        return (
+            <div style={{ display: 'inline-block' }}>
+                <div className="name">{this.props.itemList["PluginFlyvemdmInvitation.User.name"]}</div>
+                <div className="detail">{this.props.itemList["PluginFlyvemdmInvitation.status"]}</div>
+            </div>
+        )
+    }
+}

--- a/src/components/MenuListWinJs/ItemList/Settings.js
+++ b/src/components/MenuListWinJs/ItemList/Settings.js
@@ -1,0 +1,11 @@
+import React, { Component } from 'react'
+
+export default class SettingsItemList extends Component {
+    render() {
+        return (
+            <div style={{ padding: '14px', width: '100%' }}>
+                {this.props.data.title}
+            </div>
+        )
+    }
+}

--- a/src/components/MenuListWinJs/ItemList/Users.js
+++ b/src/components/MenuListWinJs/ItemList/Users.js
@@ -1,0 +1,17 @@
+import React, { Component } from 'react'
+import IconItemList from '../../IconItemList'
+
+export default class UsersItemList extends Component {
+    render() {
+        const imageProfile = this.props.itemList['User.picture'] ? this.props.itemList['User.picture'] : "profile.png"
+        return (
+            <div>
+                <IconItemList image={imageProfile} size={42} />
+                <div style={{ display: 'inline-block' }}>
+                    <div className="name">{this.props.itemList['User.name']}</div>
+                    <div className="detail">{this.props.itemList['User.realname']}</div>
+                </div>
+            </div>
+        )
+    }
+}

--- a/src/components/MenuListWinJs/ItemList/index.js
+++ b/src/components/MenuListWinJs/ItemList/index.js
@@ -1,0 +1,19 @@
+import AboutItemList from './About'
+import ApplicationsItemList from './Applications'
+import DevicesItemList from './Devices'
+import InvitationsItemList from './Invitations'
+import SettingsItemList from './Settings'
+import FilesItemList from './Files'
+import FleetsItemList from './Fleets'
+import UsersItemList from './Users'
+
+export {
+    AboutItemList,
+    ApplicationsItemList,
+    DevicesItemList,
+    InvitationsItemList,
+    SettingsItemList,
+    FilesItemList,
+    FleetsItemList,
+    UsersItemList
+}

--- a/src/components/MenuListWinJs/index.js
+++ b/src/components/MenuListWinJs/index.js
@@ -91,6 +91,9 @@ export default class ListWinJs extends Component {
                     count: 15
                 }
             })
+
+            this.props.history.replace('/app/devices')
+
             const devices = await GLPI.searchItems({ 
                 itemtype: this.props.handleRefreshRequest.itemtype, 
                 options: { 
@@ -99,12 +102,11 @@ export default class ListWinJs extends Component {
                     ...this.props.handleRefreshRequest.options
                 } 
             })
+            
             this.setState({
                 isLoading: false,
                 order: devices.order,
                 itemList: buildItemList(devices)
-            }, () => {
-                this.props.history.replace('/app/devices')
             })
             
         } catch (error) {
@@ -115,26 +117,18 @@ export default class ListWinJs extends Component {
         }
     }
 
-    handleEdit = (eventObject) => {
-        let button = eventObject.currentTarget.winControl
-        setTimeout(() => {
-            this.props.onNavigate(this.state.selectedItemList.length > 0 && this.props.selectionMode ? [this.props.location[0], this.state.selectedItemList] : this.props.location)
-            this.props.changeAction(button.label)
-        }, 0)
+    handleEdit = () => {
+        this.props.history.replace('/app/devices/edit')        
     }
 
     handlePanel = (eventObject) => {
-        let button = eventObject.currentTarget.winControl
         this.listView.winControl.selection.clear()
-        
         this.props.changeSelectionMode(false)
-        this.props.onNavigate([this.props.location[0]])
-        this.props.changeAction(button.label)
+        this.props.history.replace('/app/devices/add')
     }
 
     handleToggleSelectionMode = () => {
         this.listView.winControl.selection.clear()
-        this.props.changeAction(null)
         this.props.changeSelectionMode(!this.props.selectionMode)
         this.props.history.replace('/app/devices')
         this.setState({
@@ -406,8 +400,7 @@ ListWinJs.propTypes = {
     ]).isRequired,
     screen: PropTypes.string.isRequired,
     animation: PropTypes.bool.isRequired,
-    location: PropTypes.array.isRequired,
-    onNavigate: PropTypes.func.isRequired,
+    location: PropTypes.object.isRequired,
     selectionMode: PropTypes.bool.isRequired,
     changeSelectionMode: PropTypes.func.isRequired,
     action: PropTypes.string,

--- a/src/components/MenuListWinJs/index.js
+++ b/src/components/MenuListWinJs/index.js
@@ -1,0 +1,415 @@
+import React, { Component } from "react"
+import PropTypes from 'prop-types'
+import ReactWinJS from 'react-winjs'
+import WinJS from 'winjs'
+import buildItemList from '../../shared/buildItemList'
+import Loader from '../Loader'
+import Confirmation from '../Confirmation'
+import { AboutItemList, ApplicationsItemList, DevicesItemList, InvitationsItemList, SettingsItemList, FilesItemList, FleetsItemList, UsersItemList} from './ItemList'
+import GLPI from '../../shared/glpiApi'
+
+export default class ListWinJs extends Component {
+
+    constructor(props) {
+        super(props)
+        this.state = {
+            layout: { type: WinJS.UI.ListLayout },
+            selectedItemList: [],
+            scrolling: false,
+            isLoading: false,
+            itemList: new WinJS.Binding.List([]),
+            order: "ASC",
+            pagination: {
+                start: 0,
+                page: 1,
+                count: 15
+            }
+        }
+    }
+
+    componentDidMount() {
+        this.handleRefresh()
+    }
+
+    componentDidUpdate(prevProps) {    
+        if(this.listView && !this.state.scrolling) {
+            this.listView.winControl.footer.style.height = '1px'
+        }
+
+        if (!this.props.action && (prevProps.action === 'Edit' || prevProps.action === 'EditOne' || prevProps.action === 'Delete')) {
+            this.handleRefresh()
+        }
+
+        if (this.props.action === "reload") {
+            this.handleRefresh()
+            this.props.changeAction(null)            
+        }
+    }
+
+    componentWillUnmount() {
+        this.setState({ selectedItemList: [] })
+        this.props.changeSelectionMode(false)
+    }
+
+    ItemListRenderer = ReactWinJS.reactRenderer((ItemList) => {
+        switch (this.props.screen) {
+            case 'Devices':
+                return <DevicesItemList itemList={ItemList.data} />
+            case 'About':
+                return <AboutItemList itemList={ItemList.data} />
+            case 'Applications':
+                return <ApplicationsItemList itemList={ItemList.data} />
+            case 'Invitations':
+                return <InvitationsItemList itemList={ItemList.data} />
+            case 'Settings':
+                return <SettingsItemList itemList={ItemList.data} />
+            case 'Files':
+                return <FilesItemList itemList={ItemList.data} />          
+            case 'Fleets':
+                return <FleetsItemList itemList={ItemList.data} />
+            case 'Users':
+                return <UsersItemList itemList={ItemList.data} />
+            default:
+                return undefined
+        }
+    })
+
+    groupHeaderRenderer = ReactWinJS.reactRenderer((item) => {
+        return (
+            <div>{item.data.title}</div>
+        )
+    })
+
+    handleRefresh = async () => {
+        try {
+            // this.props.onNavigate([this.props.location[0]])
+            this.setState({
+                isLoading: true,
+                scrolling: false,
+                pagination: {
+                    start: 0,
+                    page: 1,
+                    count: 15
+                }
+            })
+            const devices = await GLPI.searchItems({ 
+                itemtype: this.props.handleRefreshRequest.itemtype, 
+                options: { 
+                    order: this.state.order, 
+                    range: `${this.state.pagination.start}-${(this.state.pagination.count * this.state.pagination.page) - 1}`,
+                    ...this.props.handleRefreshRequest.options
+                } 
+            })
+            this.setState({
+                isLoading: false,
+                order: devices.order,
+                itemList: buildItemList(devices)
+            })
+            
+        } catch (error) {
+            this.setState({
+                isLoading: false,
+                order: "ASC"
+            })
+        }
+    }
+
+    handleEdit = (eventObject) => {
+        let button = eventObject.currentTarget.winControl
+        setTimeout(() => {
+            this.props.onNavigate(this.state.selectedItemList.length > 0 && this.props.selectionMode ? [this.props.location[0], this.state.selectedItemList] : this.props.location)
+            this.props.changeAction(button.label)
+        }, 0)
+    }
+
+    handlePanel = (eventObject) => {
+        let button = eventObject.currentTarget.winControl
+        this.listView.winControl.selection.clear()
+        
+        this.props.changeSelectionMode(false)
+        this.props.onNavigate([this.props.location[0]])
+        this.props.changeAction(button.label)
+    }
+
+    handleToggleSelectionMode = () => {
+        this.listView.winControl.selection.clear()
+        this.props.changeAction(null)
+        this.props.changeSelectionMode(!this.props.selectionMode)
+        this.props.onNavigate([this.props.location[0]])  
+        this.setState({
+            selectedItemList: []
+        })
+    }
+
+    handleSelectionChanged = (eventObject) => {
+        let listView = eventObject.currentTarget.winControl
+        let index = listView.selection.getIndices()
+        let itemSelected = []
+
+        for (const item of index) {
+            itemSelected.push(this.state.itemList.getItem(item).data)
+        }
+
+        this.setState({
+            selectedItemList: itemSelected
+        })
+
+        if (this.props.action !== 'Edit') {
+               
+            setTimeout(() => {
+                if(index.length !== 0) {
+                    this.props.changeAction(null)
+                }
+                this.props.onNavigate(index.length === 1 && !this.props.selectionMode ? [this.props.location[0], this.state.selectedItemList] : this.props.location)
+            }, 0)
+        }
+    }
+
+    handleDelete = async (eventObject) => {
+        try {
+            let button = eventObject.currentTarget.winControl
+            const isOK = await Confirmation.isOK(this.contentDialog)
+            if (isOK) {
+
+                let itemListToDelete = this.state.selectedItemList.map((item) => {
+                    return {
+                        id: item[this.props.handleDeleteRequest.idKey]
+                    }
+                })
+
+                this.setState({
+                    isLoading: true
+                })
+                this.props.changeAction(button.label)
+
+                await GLPI.deleteItem({ 
+                    itemtype: this.props.handleDeleteRequest.itemtype, 
+                    input: itemListToDelete, 
+                    queryString: { force_purge: true } 
+                })
+
+                this.props.showNotification('Success', 'elements successfully removed')
+                this.props.changeAction(null)
+                this.props.changeSelectionMode(false)
+                this.setState({
+                    selectedItemList: []
+                })
+            } else {
+                // Clean another actions selected
+                this.props.changeAction(null)
+                // Exit selection mode
+                this.props.changeSelectionMode(false)
+                this.listView.winControl.selection.clear()
+                this.setState({
+                    selectedItemList: []
+                })
+            }
+            
+        } catch (error) {
+            if (error.length > 1) {
+                this.props.showNotification(error[0], error[1])
+            }
+            this.props.changeAction(null)
+            this.props.changeSelectionMode(false)
+            this.setState({
+                selectedItemList: []
+            })
+        }
+    }
+
+    handleSort = async () => {
+        try {
+            this.props.onNavigate([this.props.location[0]])
+            this.setState({
+                isLoading: true,
+                pagination: {
+                    start: 0,
+                    page: 1,
+                    count: 15
+                }
+            })
+            let newOrder = this.state.order === 'ASC' ? 'DESC' : 'ASC'
+
+            const devices = await GLPI.searchItems({ 
+                itemtype: this.props.handleSortRequest.itemtype, 
+                options: { 
+                    uid_cols: true, 
+                    order: newOrder, 
+                    ...this.props.handleSortRequest.options
+                } 
+            })
+
+            this.setState({
+                isLoading: false,
+                order: devices.order,
+                itemList: buildItemList(devices)
+            })
+
+        } catch (error) {
+            this.setState({
+                isLoading: false,
+                order: "ASC"
+            })
+        }
+    }
+
+    onLoadingStateChanged = (eventObject) => {
+        if (eventObject.detail.scrolling === true) {
+             setTimeout(() => {
+                 this.setState({
+                scrolling: true
+            })
+             }, 0)
+        }
+    }
+
+    showFooterList = (eventObject) => {
+        let listView = eventObject.currentTarget.winControl
+        if (eventObject.detail.visible && this.state.scrolling) {
+            listView.footer.style.height = '100px'
+            this.loadMoreData()
+        }
+    }
+
+    loadMoreData = async () => {
+        try {
+            const devices = await GLPI.searchItems({ 
+                itemtype: this.props.loadMoreDataRequest.itemtype, 
+                options: { 
+                    order: this.state.order, range: `${this.state.pagination.count * this.state.pagination.page}-${(this.state.pagination.count * (this.state.pagination.page + 1)) - 1}`,
+                    ...this.props.loadMoreDataRequest.options
+                } 
+            })
+            
+            for (const item in devices.data) {
+                this.state.itemList.push(devices.data[item])
+            }
+
+            this.setState({
+                pagination: {
+                    ...this.state.pagination,
+                    page: this.state.pagination.page + 1
+                }
+            })
+
+            this.listView.winControl.footer.style.height = '1px'
+
+        } catch (error) {
+            this.listView.winControl.footer.style.height = '1px'
+        }
+    }
+
+    render() {
+        let deleteCommand = (
+            <ReactWinJS.ToolBar.Button
+                key="delete"
+                icon="delete"
+                label="Delete"
+                priority={0}
+                disabled={this.state.selectedItemList.length === 0}
+                onClick={this.handleDelete}
+            />
+        )
+
+        let editCommand = (
+            <ReactWinJS.ToolBar.Button
+                key="edit"
+                icon="edit"
+                label="Edit"
+                priority={0}
+                disabled={this.state.selectedItemList.length === 0}
+                onClick={this.handleEdit}
+            />
+        )
+
+        let listComponent = <Loader count={3} />
+
+        if (!this.state.isLoading && this.state.itemList.groups !== undefined ) {
+            listComponent = (
+                <ReactWinJS.ListView
+                    ref={(listView) => { this.listView = listView }}
+                    onLoadingStateChanged={this.onLoadingStateChanged}
+                    className="contentListView win-selectionstylefilled"
+                    style={{ height: 'calc(100% - 48px)' }}
+                    itemDataSource={this.state.itemList.dataSource}
+                    groupDataSource={this.state.itemList.groups.dataSource}
+                    layout={this.state.layout}
+                    itemTemplate={this.ItemListRenderer}
+                    groupHeaderTemplate={this.groupHeaderRenderer}
+                    footerComponent={<Loader />}
+                    onFooterVisibilityChanged={this.showFooterList}
+                    selectionMode={this.props.selectionMode ? 'multi' : 'single'}
+                    tapBehavior={this.props.selectionMode ? 'toggleSelect' : 'directSelect'}
+                    onSelectionChanged={this.handleSelectionChanged}
+                />
+            )
+        }
+
+        return (
+            <React.Fragment>
+                <div className="listPane" style={{ height: '100%', width: this.props.itemListPaneWidth, display: 'inline-block', verticalAlign: 'top' }}>
+                    <ReactWinJS.ToolBar className="listToolBar">
+                        <ReactWinJS.ToolBar.Button
+                            key="sort"
+                            icon="sort"
+                            label="Sort"
+                            priority={1}
+                            onClick={this.handleSort}
+                        />
+                        <ReactWinJS.ToolBar.Button
+                            key="refresh"
+                            icon="refresh"
+                            label="Refresh"
+                            priority={2}
+                            onClick={this.handleRefresh}
+                        />
+
+                        <ReactWinJS.ToolBar.Button
+                            key="add"
+                            icon="add"
+                            label="Add"
+                            priority={0}
+                            onClick={this.handlePanel}
+                        />
+
+                        {this.props.selectionMode ? editCommand : null}
+                        {this.props.selectionMode ? deleteCommand : null}
+
+                        <ReactWinJS.ToolBar.Toggle
+                            key="select"
+                            icon="bullets"
+                            label="Select"
+                            priority={0}
+                            selected={this.props.selectionMode}
+                            onClick={this.handleToggleSelectionMode}
+                        />
+                    </ReactWinJS.ToolBar>
+                    { listComponent }
+                    <Confirmation title={`Delete ` + this.props.location[0]} message={this.state.selectedItemList.length +` `+ this.props.location[0]} reference={el => this.contentDialog = el} /> 
+                </div>
+
+                { this.props.children }
+
+            </React.Fragment>
+        )
+    }
+}
+ListWinJs.propTypes = {
+    itemListPaneWidth: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number
+    ]).isRequired,
+    screen: PropTypes.string.isRequired,
+    animation: PropTypes.bool.isRequired,
+    location: PropTypes.array.isRequired,
+    onNavigate: PropTypes.func.isRequired,
+    selectionMode: PropTypes.bool.isRequired,
+    changeSelectionMode: PropTypes.func.isRequired,
+    action: PropTypes.string,
+    changeAction: PropTypes.func.isRequired,
+    showNotification: PropTypes.func.isRequired,
+    handleRefreshRequest: PropTypes.object.isRequired,
+    handleDeleteRequest: PropTypes.object.isRequired,
+    handleSortRequest: PropTypes.object.isRequired,
+    loadMoreDataRequest: PropTypes.object.isRequired
+}

--- a/src/components/MenuListWinJs/index.js
+++ b/src/components/MenuListWinJs/index.js
@@ -82,7 +82,6 @@ export default class ListWinJs extends Component {
 
     handleRefresh = async () => {
         try {
-            // this.props.onNavigate([this.props.location[0]])
             this.setState({
                 isLoading: true,
                 scrolling: false,
@@ -104,6 +103,8 @@ export default class ListWinJs extends Component {
                 isLoading: false,
                 order: devices.order,
                 itemList: buildItemList(devices)
+            }, () => {
+                this.props.history.replace('/app/devices')
             })
             
         } catch (error) {
@@ -411,5 +412,6 @@ ListWinJs.propTypes = {
     handleRefreshRequest: PropTypes.object.isRequired,
     handleDeleteRequest: PropTypes.object.isRequired,
     handleSortRequest: PropTypes.object.isRequired,
-    loadMoreDataRequest: PropTypes.object.isRequired
+    loadMoreDataRequest: PropTypes.object.isRequired,
+    history: PropTypes.object.isRequired
 }

--- a/src/components/MenuListWinJs/index.js
+++ b/src/components/MenuListWinJs/index.js
@@ -161,7 +161,11 @@ export default class ListWinJs extends Component {
                 if(index.length !== 0) {
                     this.props.changeAction(null)
                 }
-                this.props.onNavigate(index.length === 1 && !this.props.selectionMode ? [this.props.location[0], this.state.selectedItemList] : this.props.location)
+                if (index.length === 1 && !this.props.selectionMode) {
+                    this.props.history.replace(
+                        `/app/devices/${this.state.selectedItemList[0]['PluginFlyvemdmAgent.id']}`
+                    )
+                }
             }, 0)
         }
     }

--- a/src/components/MenuListWinJs/index.js
+++ b/src/components/MenuListWinJs/index.js
@@ -224,7 +224,7 @@ export default class ListWinJs extends Component {
 
     handleSort = async () => {
         try {
-            this.props.onNavigate([this.props.location[0]])
+            this.props.history.replace('/app/devices')
             this.setState({
                 isLoading: true,
                 pagination: {

--- a/src/components/MenuListWinJs/index.js
+++ b/src/components/MenuListWinJs/index.js
@@ -136,7 +136,7 @@ export default class ListWinJs extends Component {
         this.listView.winControl.selection.clear()
         this.props.changeAction(null)
         this.props.changeSelectionMode(!this.props.selectionMode)
-        this.props.onNavigate([this.props.location[0]])  
+        this.props.history.replace('/app/devices')
         this.setState({
             selectedItemList: []
         })

--- a/src/components/SplitView/IconWithPopper/index.js
+++ b/src/components/SplitView/IconWithPopper/index.js
@@ -21,4 +21,4 @@ const iconWithPopper = ({to, iconName, title, disabled, click}) => {
   }
 }
  
-export default iconWithPopper;
+export default iconWithPopper

--- a/src/components/SplitView/index.js
+++ b/src/components/SplitView/index.js
@@ -120,4 +120,4 @@ const splitView = ({
   )
 }
   
-export default splitView;
+export default splitView

--- a/src/containers/Devices/routes.js
+++ b/src/containers/Devices/routes.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import { I18n } from 'react-i18nify'
+
+const MonkComponent1 = () => <div><h1> Mock1 </h1></div>
+const MonkComponent2 = () => <div><h1> Mock2 </h1></div>
+const MonkComponent3 = () => <div><h1> Mock3 </h1></div>
+const MonkComponent4 = () => <div><h1> Mock4 </h1></div>
+const MonkComponent5 = () => <div><h1> Mock5 </h1></div>
+
+const routes = [
+  {
+    path: '/',
+    name: I18n.t('about.overview'),
+    component: MonkComponent1,
+    exact: true
+  },
+  // {
+  //   path: '/system',
+  //   name: I18n.t('about.system_information'),
+  //   component: MonkComponent3,
+  //   exact: false
+  // },
+  // {
+  //   path: '/help',
+  //   name: I18n.t('about.help_center'),
+  //   component: MonkComponent4,
+  //   exact: false
+  // },
+  // {
+  //   path: '/contact',
+  //   name: I18n.t('about.contact'),
+  //   component: MonkComponent1,
+  //   exact: false
+  // },
+  // {
+  //   path: '/release',
+  //   name: I18n.t('about.release_notes'),
+  //   component: MonkComponent2,
+  //   exact: false
+  // },
+  // {
+  //   path: '/term',
+  //   name: I18n.t('about.term_of_use'),
+  //   component: MonkComponent4,
+  //   exact: false
+  // },
+  // {
+  //   path: '/license',
+  //   name: I18n.t('about.license'),
+  //   component: MonkComponent5,
+  //   exact: false
+  // }
+]
+
+export default routes

--- a/src/containers/Settings/index.js
+++ b/src/containers/Settings/index.js
@@ -14,4 +14,4 @@ class Settings extends Component {
     }
 }
 
-export default Settings;
+export default Settings

--- a/src/shared/buildItemList.js
+++ b/src/shared/buildItemList.js
@@ -1,0 +1,48 @@
+import WinJS from 'winjs'
+
+export default function (dataSource) {
+
+    const groupKey = function (data) {
+        return (data[Object.keys(data)[0]])[0].toUpperCase()
+    }
+
+    const groupData = function (data) {
+        return { title: groupKey(data) }
+    }
+
+    const groupSorted = function (a, b) {
+        if (dataSource.order === 'ASC') {
+            if (a < b) {
+                return -1
+            } else if (a > b) {
+                return 1
+            } else {
+                return 0
+            }
+        } else {
+            if (a > b) {
+                return -1
+            } else if (a < b) {
+                return 1
+            } else {
+                return 0
+            }
+        }
+    }
+
+    const sorter = (a, b) => {
+        if (a[Object.keys(a)[0]] < b[Object.keys(b)[0]]) {
+            return -1
+        } else if (a[Object.keys(a)[0]] > b[Object.keys(b)[0]]) {
+            return 1
+        } else {
+            return 0
+        }
+    }
+
+    if (dataSource.data) {
+        return new WinJS.Binding.List(dataSource.data)
+            .createSorted(sorter)
+            .createGrouped(groupKey, groupData, groupSorted)
+    }
+}


### PR DESCRIPTION
Signed-off-by: Gianfranco Manganiello <gmanganiello@teclib.com>

### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->
In this PR: 
- Move buildItemList to the new structure 
- Add some styles of listPane 
- Receive porps correctly in IconItemList
- Fix main routes 
- Create a generic component of winjs lists 
- Move item templates of about, applications, devices, files, fleets, invitations, settings, and users
- Improve the appearance of the list 
- Add '/' to the 'images' routes 
- Clear the route after reloading the menu list 
- Add to the route the id of the selected element 
- Clean the route when changing the selection mode 
- Clean the route when the list is reorganized
- Add 'edit' to the route of multiple editions 


![captura de pantalla 2018-03-05 a la s 9 59 01 a m](https://user-images.githubusercontent.com/19965590/36991008-ca633700-207c-11e8-95e5-05d9cd16c0af.png)


### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A