### PR TITLE
Responsive sections and box-shadow

### DIFF
--- a/src/assets/styles/architecture/4_level_elements/_input_and_textarea.scss
+++ b/src/assets/styles/architecture/4_level_elements/_input_and_textarea.scss
@@ -1,4 +1,7 @@
-.win-textbox:focus, .win-textarea:focus {
-    border-color: $app-color !important;
+.win-textbox, .win-textarea {
     box-shadow: none;
+    
+    &:focus {
+        border-color: $app-color !important;
+    }
 }

--- a/src/hoc/withAdminDashboardLayout/index.js
+++ b/src/hoc/withAdminDashboardLayout/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import SplitView from "../../components/SplitView"
 import HeaderBreadcrumb from '../../components/HeaderBreadcrumb'
+import getMode from '../../shared/getMode'
 
 // TODO: Passing Routes to props for generate NavLink in SplitView component
 
@@ -12,8 +13,26 @@ const withAdminDashboardLayout = WrappedComponent => {
       super(props)
       this.state = {
         expanded: false,
-        contract: false
+        contract: false,
+        mode: getMode()
       }
+    }
+
+    handleResize = () => {
+      let prevMode = this.state.mode
+      let nextMode = getMode()
+
+      if (prevMode !== nextMode) {
+          this.setState({mode: nextMode})
+      }
+    }
+
+    componentWillMount () {
+      window.addEventListener('resize', this.handleResize)
+    }
+
+    componentWillUnmount () {
+      window.removeEventListener('resize', this.handleResize)
     }
 
     handleToggleExpand = () => {
@@ -60,7 +79,7 @@ const withAdminDashboardLayout = WrappedComponent => {
               handleSetTimeOut={this.handleSetTimeOut}
               handleToggleExpand={this.handleToggleExpand}
             />
-            <WrappedComponent {...this.props} />
+            <WrappedComponent {...this.props} mode={this.state.mode} />
           </div>
         
         </main>


### PR DESCRIPTION
### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->
In this PR:
- Show only the necessary components by resolution 
- Remove box-shadow of inputs

![localhost_3000_app_invitations](https://user-images.githubusercontent.com/19965590/37172731-05866b1e-22e8-11e8-828b-1abede69ec2b.png)
![localhost_3000_app_invitations 1](https://user-images.githubusercontent.com/19965590/37172733-05bc711e-22e8-11e8-9ed8-d88a1008211b.png)
![captura de pantalla 2018-03-08 a la s 3 47 13 p m](https://user-images.githubusercontent.com/19965590/37172737-0918f2c4-22e8-11e8-8acf-a2a90cbbc887.png)


### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Close: #444 
Close: #422 