### PR TITLE
Fix the conflict of the double key in Jekyll

### DIFF
--- a/ci/scripts/add_space.rb
+++ b/ci/scripts/add_space.rb
@@ -1,0 +1,13 @@
+
+# Add spaces between '{{' and '}}' characters
+Dir.glob("coverage/**/*.html") do |file_name|
+    text = File.read(file_name)
+    replace = text.gsub!(/{{/, "{ {")
+    if replace
+        File.open(file_name, "w") { |file| file.puts replace }
+    end
+    replace = text.gsub!(/}}/, "} }")
+    if replace
+        File.open(file_name, "w") { |file| file.puts replace }
+    end
+end

--- a/ci/scripts/deploy_develop.sh
+++ b/ci/scripts/deploy_develop.sh
@@ -16,6 +16,8 @@ yarn gh-pages-docs -m "ci(docs): generate documentation with jsdoc for version $
 yarn coverage
 # Add headers to all HTML files of the coverage
 ruby ci/scripts/add_header.rb
+# Add spaces between '{{' and '}}' characters in the coverage
+ruby ci/scripts/add_space.rb
 # Add docs folder
 git add coverage -f
 # Create commit, NOTICE: this commit is not sent


### PR DESCRIPTION
Signed-off-by: Gianfranco Manganiello <gmanganiello@teclib.com>

### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->
In this PR:
- Add spaces between '{{' and '}}' characters

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Ref: #249