### PR TITLE
Self-registration link in errors of login

### DIFF
--- a/src/containers/SignIn/components/UsernameFieldset.js
+++ b/src/containers/SignIn/components/UsernameFieldset.js
@@ -89,7 +89,11 @@ class UsernameFieldset extends PureComponent {
                 errorMessage: (
                     <p className="color-type-alert"> 
                         <span> {I18n.t('login.username_not_registered')} </span> 
-                        <a>{I18n.t('login.create_an_new')}</a>
+                        {
+                            this.state.selfRegistration ?
+                                <Link to={`${publicURL}/signUp`}>{I18n.t('login.create_an_new')}</Link>
+                                : null
+                        }
                     </p>
                 )
             })


### PR DESCRIPTION
Signed-off-by: Gianfranco Manganiello <gmanganiello@teclib.com>

### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->
In this PR, improve handling of the 'unregistered user name' error:
  - Fix internal link to the user registration screen
  - Validate if self-registration is enabled before providing the link

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A