### PR TITLE
Handle 40x errors internally

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,49 @@
+# .htaccess for production server
+
+# url relative to web root dir
+SetEnvIf Host ^ DASHBOARD_WEBROOT /
+
+#Custom error pages
+ErrorDocument 400 /build/error?code=400
+ErrorDocument 401 /build/error?code=401
+ErrorDocument 403 /build/error?code=403
+ErrorDocument 404 /build/error?code=404
+ErrorDocument 500 /build/error?code=500
+
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteBase /build/
+    RewriteRule ^index\.html$ - [L]
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteRule . /build/index.html [L]
+</IfModule>
+
+# DISABLE ALL CACHING WHILE DEVELOPING
+<FilesMatch "\.(html|htm|js|css|json)$">
+  FileETag None
+
+  <IfModule mod_headers.c>
+    Header unset ETag
+    Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+    Header set Pragma "no-cache"
+    Header set Note "CACHING IS DISABLED ON LOCALHOST OR DEVELOP"
+    Header set Expires "Wed, 11 Jan 1984 05:00:00 GMT"
+  </IfModule>
+</FilesMatch>
+
+# EXPIRES CACHING
+<IfModule mod_expires.c>
+  ExpiresActive On
+  ExpiresByType image/jpg "access 1 year"
+  ExpiresByType image/jpeg "access 1 year"
+  ExpiresByType image/gif "access 1 year"
+  ExpiresByType image/png "access 1 year"
+  ExpiresByType text/css "access 1 month"
+  ExpiresByType text/html "access 1 month"
+  ExpiresByType application/pdf "access 1 month"
+  ExpiresByType text/x-javascript "access 1 month"
+  ExpiresByType application/x-shockwave-flash "access 1 month"
+  ExpiresByType image/x-icon "access 1 year"
+  ExpiresDefault "access 1 month"
+</IfModule>

--- a/gitlabRunner.sh
+++ b/gitlabRunner.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+webroot="/var/www/public/dashboard"
+
 # set transifex credentials and update the translations
 cat /dev/null > ~/.transifexrc
 echo "[https://www.transifex.com]" >> ~/.transifexrc
@@ -20,6 +22,12 @@ source ci/scripts/create_config_file.sh
 # build the dashboard
 yarn build
 source ci/scripts/sitemap_generator.sh
-rm -r /var/www/public/dashboard
-cp -r ./build /var/www/public/dashboard
-cp -f ./htaccess_dev /var/www/public/dashboard/.htaccess
+rm -r ${webroot}
+cp -r ./build ${webroot}
+
+# set the production htaccess for public web site
+cp -f ./htaccess_prod ${webroot}/.htaccess
+
+# change web server options for development environment
+sed -i -- 's/DASHBOARD_WEBROOT \//DASHBOARD_WEBROOT \/dashboard\//g' ${webroot}/.htaccess
+cat ./htaccess_dev >> ${webroot}/.htaccess

--- a/htaccess_dev
+++ b/htaccess_dev
@@ -1,12 +1,3 @@
-<IfModule mod_rewrite.c>
-    RewriteEngine On
-    RewriteBase /dashboard
-    RewriteRule ^index\.html$ - [L]
-    RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteRule . /dashboard/index.html [L]
-</IfModule>
-
 # DISABLE ALL CACHING WHILE DEVELOPING
 <FilesMatch "\.(html|htm|js|css|json)$">
   FileETag None

--- a/htaccess_prod
+++ b/htaccess_prod
@@ -1,0 +1,11 @@
+# .htaccess for production server
+
+# url relative to web root dir
+SetEnvIf Host ^ DASHBOARD_WEBROOT /
+
+#Custom error pages
+ErrorDocument 400 %{ENV:DASHBOARD_WEBROOT}error?code=400
+ErrorDocument 401 %{ENV:DASHBOARD_WEBROOT}error?code=401
+ErrorDocument 403 %{ENV:DASHBOARD_WEBROOT}error?code=403
+ErrorDocument 404 %{ENV:DASHBOARD_WEBROOT}error?code=404
+ErrorDocument 500 %{ENV:DASHBOARD_WEBROOT}error?code=500

--- a/htaccess_prod
+++ b/htaccess_prod
@@ -9,3 +9,12 @@ ErrorDocument 401 %{ENV:DASHBOARD_WEBROOT}error?code=401
 ErrorDocument 403 %{ENV:DASHBOARD_WEBROOT}error?code=403
 ErrorDocument 404 %{ENV:DASHBOARD_WEBROOT}error?code=404
 ErrorDocument 500 %{ENV:DASHBOARD_WEBROOT}error?code=500
+
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteBase %{ENV:DASHBOARD_WEBROOT}
+    RewriteRule ^index\.html$ - [L]
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteRule . %{ENV:DASHBOARD_WEBROOT}index.html [L]
+</IfModule>

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "webpack-dev-server": "^2.11.2",
     "webpack-manifest-plugin": "2.0.3"
   },
-  "homepage": "https://dev.flyve.org/dashboard",
+  "homepage": ".",
   "babel": {
     "presets": [
       "react-app"

--- a/src/assets/styles/architecture/5_level_components/_error.scss
+++ b/src/assets/styles/architecture/5_level_components/_error.scss
@@ -1,0 +1,5 @@
+.error {
+    max-width: 360px;
+    margin: 0 auto;
+    padding: 0 20px;
+}

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -52,7 +52,8 @@
     './architecture/5_level_components/file_upload',
     './architecture/5_level_components/empty_message',
     './architecture/5_level_components/badge',
-    './architecture/5_level_components/tooltip';
+    './architecture/5_level_components/tooltip',
+    './architecture/5_level_components/error';
 
 // Level 6
 @import 

--- a/src/components/ErrorPage/__tests__/ErrorPage.snapshot.js
+++ b/src/components/ErrorPage/__tests__/ErrorPage.snapshot.js
@@ -27,40 +27,16 @@
  */
 
 import React from 'react'
-import I18n from '../../shared/i18n'
-import img from '../../assets/images/dashboard.svg'
+import renderer from 'react-test-renderer'
 
+import ErrorPage from "../index"
 
-/**
- * Component used in the page of error 404
- * @function NotFound
- * @return {component} Page of error 404
- */
-const NotFound = () => (
-  <div className="authentication" style={{ textAlign: 'center' }}>
-    <section>
-      <figure>
-        <img alt="Flyve MDM Dashboard" src={img} />
-      </figure>
-      <h1>
-        {I18n.t('commons.not_found')}
-      </h1>
-      <h1>
-        404
-      </h1>
-    </section>
-    <footer>
-      <a href="https://flyve-mdm.com/privacy-policy/">
-        {I18n.t('commons.terms_and_conditions')}
-      </a>
-      <br />
-
-      <span>
-        { "© 2017 - 2018 Teclib'." }
-      </span>
-      <br />
-    </footer>
-  </div>
-)
-
-export default NotFound
+describe('ErrorPage', () => {
+  test('renders ErrorPage', () => {
+    const component = renderer.create(
+      <ErrorPage />
+    )
+    const tree = component.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/src/components/ErrorPage/__tests__/__snapshots__/ErrorPage.snapshot.js.snap
+++ b/src/components/ErrorPage/__tests__/__snapshots__/ErrorPage.snapshot.js.snap
@@ -2,43 +2,38 @@
 
 exports[`ErrorPage renders ErrorPage 1`] = `
 <div
-  className="authentication error"
+  className="empty-message"
   style={
     Object {
-      "textAlign": "center",
+      "width": "100%",
     }
   }
 >
-  <section>
+  <div
+    style={
+      Object {
+        "margin": "0 auto",
+        "width": "320px",
+      }
+    }
+  >
     <figure>
       <img
         alt="Flyve MDM Dashboard"
         src="dashboard.svg"
+        style={
+          Object {
+            "width": "80px",
+          }
+        }
       />
     </figure>
     <h1>
-      Error
-       
-      404
-    </h1>
-    <h3>
       Oops! Page not Found.
-    </h3>
+    </h1>
     <p>
       We could not find the page you were looking for. Meanwhile, you may return to the dashboard.
     </p>
-  </section>
-  <footer>
-    <a
-      href="https://flyve-mdm.com/privacy-policy/"
-    >
-      Terms and Conditions
-    </a>
-    <br />
-    <span>
-      © 2017 - 2018 Teclib'.
-    </span>
-    <br />
-  </footer>
+  </div>
 </div>
 `;

--- a/src/components/ErrorPage/__tests__/__snapshots__/ErrorPage.snapshot.js.snap
+++ b/src/components/ErrorPage/__tests__/__snapshots__/ErrorPage.snapshot.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NotFound renders NotFound 1`] = `
+exports[`ErrorPage renders ErrorPage 1`] = `
 <div
-  className="authentication"
+  className="authentication error"
   style={
     Object {
       "textAlign": "center",
@@ -17,11 +17,16 @@ exports[`NotFound renders NotFound 1`] = `
       />
     </figure>
     <h1>
-      Not Found
-    </h1>
-    <h1>
+      Error
+       
       404
     </h1>
+    <h3>
+      Oops! Page not Found.
+    </h3>
+    <p>
+      We could not find the page you were looking for. Meanwhile, you may return to the dashboard.
+    </p>
   </section>
   <footer>
     <a

--- a/src/components/ErrorPage/index.js
+++ b/src/components/ErrorPage/index.js
@@ -26,17 +26,39 @@
  * ------------------------------------------------------------------------------
  */
 
-import React from 'react'
-import renderer from 'react-test-renderer'
+import React from "react"
+import history from "../../shared/history"
+import getQueryString from "../../shared/getQueryString"
+import I18n from '../../shared/i18n'
 
-import NotFound from '../index'
+export default () => {
+  const errorCode = (getQueryString(history).code || "404")
+  const title = I18n.t(`error.${errorCode}.title`)
+  const message = I18n.t(`error.${errorCode}.message`)
+  return (
+    <div className="authentication error" style={{ textAlign: 'center'}} >
+      <section>
+        <figure>
+          <img
+            alt="Flyve MDM Dashboard"
+            src={require('../../assets/images/dashboard.svg')}
+          />
+        </figure>
+        <h1>{I18n.t('commons.error')} {errorCode}</h1>
+        <h3>{title}</h3>
+        <p>{message}</p>
+      </section>
+      <footer>
+        <a href="https://flyve-mdm.com/privacy-policy/">
+          {I18n.t('commons.terms_and_conditions')}
+        </a>
+        <br />
 
-describe('NotFound', () => {
-  test('renders NotFound', () => {
-    const component = renderer.create(
-      <NotFound />,
-    )
-    const tree = component.toJSON()
-    expect(tree).toMatchSnapshot()
-  })
-})
+        <span>
+          © 2017 - 2018 Teclib'.
+        </span>
+        <br />
+      </footer>
+    </div>
+  )
+}

--- a/src/components/ErrorPage/index.js
+++ b/src/components/ErrorPage/index.js
@@ -31,7 +31,13 @@ import history from "../../shared/history"
 import getQueryString from "../../shared/getQueryString"
 import I18n from '../../shared/i18n'
 
+/**
+ * Component with the display of the error pages
+ * @function ErrorPage
+ * @return {component}
+ */
 export default () => {
+  /** Get the error type of the query string 'code' (by default '404'). */
   const errorCode = (getQueryString(history).code || "404")
   const title = I18n.t(`error.${errorCode}.title`)
   const message = I18n.t(`error.${errorCode}.message`)

--- a/src/components/ErrorPage/index.js
+++ b/src/components/ErrorPage/index.js
@@ -38,7 +38,10 @@ import I18n from '../../shared/i18n'
  */
 export default () => {
   /** Get the error type of the query string 'code' (by default '404'). */
-  const errorCode = (getQueryString(history).code || "404")
+  let errorCode = getQueryString(history).code
+  if (errorCode !== '400' && errorCode !== '401' && errorCode !== '403' && errorCode !== '404' && errorCode !== '500') {
+    errorCode = '404'
+  }
   const title = I18n.t(`error.${errorCode}.title`)
   const message = I18n.t(`error.${errorCode}.message`)
   return (

--- a/src/components/ErrorPage/index.js
+++ b/src/components/ErrorPage/index.js
@@ -30,6 +30,7 @@ import React from "react"
 import history from "../../shared/history"
 import getQueryString from "../../shared/getQueryString"
 import I18n from '../../shared/i18n'
+import EmptyMessage from '../../components/EmptyMessage'
 
 /**
  * Component with the display of the error pages
@@ -44,6 +45,30 @@ export default () => {
   }
   const title = I18n.t(`error.${errorCode}.title`)
   const message = I18n.t(`error.${errorCode}.message`)
+
+  if (errorCode !== 404 && errorCode < 500) {
+    return(
+      <div
+        className="empty-message"
+        style={{width: '100%'}}
+      >
+        <div style={{width: '320px', margin: '0 auto'}}>
+          <figure>
+            <img
+              alt="Flyve MDM Dashboard"
+              src={require('../../assets/images/dashboard.svg')}
+              style={{
+                width: '80px',
+              }}
+            />
+          </figure>
+          <h1>{title}</h1>
+          <p>{message}</p>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="authentication error" style={{ textAlign: 'center'}} >
       <section>

--- a/src/components/GenerateRoutes/index.js
+++ b/src/components/GenerateRoutes/index.js
@@ -30,7 +30,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Route, Switch } from 'react-router-dom'
 import PropsRoute from './PropsRoute'
-import NotFound from '../NotFound'
+import ErrorPage from '../../components/ErrorPage'
 
 // TODO: Enable PrivateRoute if route if private
 
@@ -39,7 +39,7 @@ import NotFound from '../NotFound'
  * @function GenerateRoutes
  * @param {array} routes
  * @param {string} rootPath
- * @param {*} withNotFound
+ * @param {boolean} withNotFound
  * @param {object} data
  * @return {component}
  */
@@ -67,7 +67,7 @@ const GenerateRoutes = (props) => {
     && r.push(
       <Route
         key={props.routes.length + 1}
-        render={() => <NotFound />}
+        render={() => <ErrorPage />}
       />,
     )
 

--- a/src/containers/Applications/components/ApplicationsList.js
+++ b/src/containers/Applications/components/ApplicationsList.js
@@ -40,6 +40,7 @@ import Confirmation from '../../../components/Confirmation'
 import EmptyMessage from '../../../components/EmptyMessage'
 import itemtype from '../../../shared/itemtype'
 import publicURL from '../../../shared/publicURL'
+import handleMessage from '../../../shared/handleMessage'
 
 /**
  * @class ApplicationsList
@@ -163,6 +164,7 @@ export default class ApplicationsList extends PureComponent {
         totalcount: response.totalcount,
       })
     } catch (error) {
+      handleMessage({ message: error })
       this.setState({
         isLoading: false,
         order: 'ASC',

--- a/src/containers/Applications/routes.js
+++ b/src/containers/Applications/routes.js
@@ -29,6 +29,7 @@
 /** import dependencies */
 import I18n from '../../shared/i18n'
 import EmptyMessage from '../../components/EmptyMessage'
+import ErrorPage from '../../components/ErrorPage'
 import DevicesContent from './components/ApplicationsContent'
 import ApplicationsAdd from './components/ApplicationsAdd'
 import ApplicationsEdit from './components/ApplicationsEdit'
@@ -42,6 +43,12 @@ const routes = [{
   path: '/',
   name: I18n.t('commons.no_selection'),
   component: EmptyMessage,
+  exact: true,
+},
+{
+  path: '/error',
+  name: I18n.t('commons.error'),
+  component: ErrorPage,
   exact: true,
 },
 {

--- a/src/containers/Devices/components/DevicesList.js
+++ b/src/containers/Devices/components/DevicesList.js
@@ -41,6 +41,7 @@ import Confirmation from '../../../components/Confirmation'
 import EmptyMessage from '../../../components/EmptyMessage'
 import itemtype from '../../../shared/itemtype'
 import publicURL from '../../../shared/publicURL'
+import handleMessage from '../../../shared/handleMessage'
 
 /**
  * @class DevicesList
@@ -226,6 +227,7 @@ export default class DevicesList extends PureComponent {
         itemList: BuildItemList(devices),
       })
     } catch (error) {
+      handleMessage({ message: error })
       this.setState({
         isLoading: false,
         order: 'ASC',

--- a/src/containers/Devices/routes.js
+++ b/src/containers/Devices/routes.js
@@ -28,6 +28,7 @@
 
 import I18n from '../../shared/i18n'
 import EmptyMessage from '../../components/EmptyMessage'
+import ErrorPage from '../../components/ErrorPage'
 import DevicesContent from './components/DevicesContent'
 import Enroll from './components/Enroll'
 import DevicesEditOne from './components/DevicesEditOne'
@@ -42,6 +43,12 @@ const routes = [{
   path: '/',
   name: I18n.t('commons.no_selection'),
   component: EmptyMessage,
+  exact: true,
+},
+{
+  path: '/error',
+  name: I18n.t('commons.error'),
+  component: ErrorPage,
   exact: true,
 },
 {

--- a/src/containers/Files/components/FilesList.js
+++ b/src/containers/Files/components/FilesList.js
@@ -40,6 +40,7 @@ import Confirmation from '../../../components/Confirmation'
 import EmptyMessage from '../../../components/EmptyMessage'
 import itemtype from '../../../shared/itemtype'
 import publicURL from '../../../shared/publicURL'
+import handleMessage from '../../../shared/handleMessage'
 
 /**
  * @class FilesList
@@ -159,6 +160,7 @@ class FilesList extends PureComponent {
           totalcount: files.totalcount,
         })
       } catch (error) {
+        handleMessage({ message: error })
         this.setState({
           isLoading: false,
           order: 'ASC',

--- a/src/containers/Files/routes.js
+++ b/src/containers/Files/routes.js
@@ -32,6 +32,7 @@ import EmptyMessage from '../../components/EmptyMessage'
 import FilesAdd from './components/FilesAdd'
 import FilesEdit from './components/FilesEdit'
 import FilesContent from './components/FilesContent'
+import ErrorPage from '../../components/ErrorPage'
 
 /**
  * Represents all routes from Files section
@@ -42,6 +43,12 @@ const routes = [{
   path: '/',
   name: I18n.t('commons.no_selection'),
   component: EmptyMessage,
+  exact: true,
+},
+{
+  path: '/error',
+  name: I18n.t('commons.error'),
+  component: ErrorPage,
   exact: true,
 },
 {

--- a/src/containers/Fleets/components/FleetsList.js
+++ b/src/containers/Fleets/components/FleetsList.js
@@ -40,6 +40,7 @@ import Confirmation from '../../../components/Confirmation'
 import EmptyMessage from '../../../components/EmptyMessage'
 import itemtype from '../../../shared/itemtype'
 import publicURL from '../../../shared/publicURL'
+import handleMessage from '../../../shared/handleMessage'
 
 /**
  * @class FleetsList
@@ -416,6 +417,7 @@ export default class FleetsList extends PureComponent {
         itemList: new WinJS.Binding.List(fleets.data),
       })
     } catch (error) {
+      handleMessage({ message: error })
       this.props.toast.setNotification(handleMessage({
         type: 'alert',
         error,

--- a/src/containers/Fleets/routes.js
+++ b/src/containers/Fleets/routes.js
@@ -30,6 +30,7 @@
 import I18n from '../../shared/i18n'
 import FleetsContent from './components/FleetsContent'
 import EmptyMessage from '../../components/EmptyMessage'
+import ErrorPage from '../../components/ErrorPage'
 import DevicesAssociated from './components/DevicesAssociated'
 import FleetsEdit from './components/FleetsEdit'
 
@@ -43,6 +44,12 @@ const routes = [
     path: '/',
     name: I18n.t('commons.no_selection'),
     component: EmptyMessage,
+    exact: true,
+  },
+  {
+    path: '/error',
+    name: I18n.t('commons.error'),
+    component: ErrorPage,
     exact: true,
   },
   {

--- a/src/containers/Invitations/components/InvitationsList.js
+++ b/src/containers/Invitations/components/InvitationsList.js
@@ -41,6 +41,7 @@ import Confirmation from '../../../components/Confirmation'
 import EmptyMessage from '../../../components/EmptyMessage'
 import itemtype from '../../../shared/itemtype'
 import publicURL from '../../../shared/publicURL'
+import handleMessage from '../../../shared/handleMessage'
 
 /**
  * Component with the list of invitations
@@ -241,6 +242,7 @@ export default class InvitationsList extends PureComponent {
         totalcount: invitations.totalcount,
       })
     } catch (error) {
+      handleMessage({ message: error })
       this.setState({
         isLoading: false,
         order: 'ASC',

--- a/src/containers/Invitations/routes.js
+++ b/src/containers/Invitations/routes.js
@@ -29,6 +29,7 @@
 /** import dependencies */
 import I18n from '../../shared/i18n'
 import EmptyMessage from '../../components/EmptyMessage'
+import ErrorPage from '../../components/ErrorPage'
 import InvitationsPendingPage from './components/InvitationsPendingPage'
 import Enroll from '../Devices/components/Enroll'
 
@@ -41,6 +42,12 @@ const routes = [{
   path: '/',
   name: I18n.t('commons.no_selection'),
   component: EmptyMessage,
+  exact: true,
+},
+{
+  path: '/error',
+  name: I18n.t('commons.error'),
+  component: ErrorPage,
   exact: true,
 },
 {

--- a/src/containers/Users/components/UsersList.js
+++ b/src/containers/Users/components/UsersList.js
@@ -41,6 +41,7 @@ import Confirmation from '../../../components/Confirmation'
 import EmptyMessage from '../../../components/EmptyMessage'
 import itemtype from '../../../shared/itemtype'
 import publicURL from '../../../shared/publicURL'
+import handleMessage from '../../../shared/handleMessage'
 
 /**
  * Component with the list of users
@@ -238,6 +239,7 @@ export default class UsersList extends PureComponent {
         totalcount: response.totalcount,
       })
     } catch (e) {
+      handleMessage({ message: e })
       this.setState({
         isLoading: false,
         order: 'ASC',

--- a/src/containers/Users/routes.js
+++ b/src/containers/Users/routes.js
@@ -29,6 +29,7 @@
 /** import dependencies */
 import I18n from '../../shared/i18n'
 import EmptyMessage from '../../components/EmptyMessage'
+import ErrorPage from '../../components/ErrorPage'
 import UsersContent from './components/UsersContent'
 import UsersEditOne from './components/UsersEditOne'
 import UsersEdit from './components/UsersEdit'
@@ -42,6 +43,12 @@ const routes = [{
   path: '/',
   name: I18n.t('commons.no_selection'),
   component: EmptyMessage,
+  exact: true,
+},
+{
+  path: '/error',
+  name: I18n.t('commons.error'),
+  component: ErrorPage,
   exact: true,
 },
 {

--- a/src/hoc/withI18NTranslation/index.js
+++ b/src/hoc/withI18NTranslation/index.js
@@ -1,0 +1,129 @@
+/*
+ *   Copyright © 2018 Teclib. All rights reserved.
+ *
+ *   This file is part of web-mdm-dashboard
+ *
+ * web-mdm-dashboard is a subproject of Flyve MDM. Flyve MDM is a mobile
+ * device management software.
+ *
+ * Flyve MDM is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * Flyve MDM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * ------------------------------------------------------------------------------
+ * @author     Gianfranco Manganiello (gmanganiello@teclib.com)
+ * @author     Hector Rondon (hrondon@teclib.com)
+ * @copyright  Copyright © 2018 Teclib. All rights reserved.
+ * @license    GPLv3 https://www.gnu.org/licenses/gpl-3.0.html
+ * @link       https://github.com/flyve-mdm/web-mdm-dashboard
+ * @link       http://flyve.org/web-mdm-dashboard
+ * @link       https://flyve-mdm.com
+ * ------------------------------------------------------------------------------
+ */
+
+import React, {
+  PureComponent
+} from 'react'
+import PropTypes from 'prop-types'
+import {
+  I18n
+} from 'react-i18nify'
+import {
+  connect
+} from 'react-redux'
+import {
+  withRouter
+} from 'react-router'
+import source_file_translation from './i18n/source_file.json'
+
+function mapStateToProps(state, props) {
+  return {
+    languageDefault: state.language.languageDefault,
+    languageCurrent: state.language.languageCurrent
+  }
+}
+
+/**
+ * Wrapper component to add the translations
+ * @param {component} WrappedComponent React Component
+ * @return {component} The translated component
+ */
+const withI18NTranslation = WrappedComponent => {
+  class I18NTranslation extends PureComponent {
+    /** @constructor */
+    constructor(props) {
+      super(props)
+      I18n.setTranslations({
+        [this.props.languageDefault]: source_file_translation
+      })
+    }
+
+    /**
+     * Find translation
+     * @function findI18NString
+     * @param {string} i18nConvention
+     */
+    findI18NString = i18nConvention => {
+      let path = i18nConvention === this.props.languageDefault ?
+        `./i18n/source_file` :
+        `./i18n/translations/${i18nConvention}`
+
+      import (`${path}.json`)
+      .then(jsonModule => {
+        I18n.setTranslations({
+          [i18nConvention]: jsonModule
+        })
+        I18n.setLocale(i18nConvention)
+        this.forceUpdate()
+      }).catch((error) => {
+        I18n.setTranslations(this.props.languageDefault)
+        this.forceUpdate()
+      })
+    }
+
+    /**
+     * Execute findI18NString if it's necessary
+     * @function componentDidUpdate
+     * @param {object} prevProps
+     */
+    componentDidUpdate(prevProps) {
+      if (this.props.languageCurrent !== prevProps.languageCurrent) {
+        this.findI18NString(this.props.languageCurrent)
+      }
+    }
+
+    /**
+     * Execute componentDidMount
+     * @function componentDidMount
+     */
+    componentDidMount() {
+      this.findI18NString(this.props.languageCurrent)
+    }
+
+    /**
+     * Render component
+     * @function render
+     */
+    render() {
+      return <WrappedComponent { ...this.props
+      }
+      />
+    }
+  }
+
+  I18NTranslation.propTypes = {
+    languageDefault: PropTypes.string.isRequired,
+    languageCurrent: PropTypes.string.isRequired
+  }
+
+  return withRouter(
+    connect(mapStateToProps, null)(I18NTranslation)
+  )
+}
+
+export default withI18NTranslation

--- a/src/shared/getQueryString/__test__/getQueryString.spec.js
+++ b/src/shared/getQueryString/__test__/getQueryString.spec.js
@@ -1,0 +1,40 @@
+/*
+*   Copyright © 2018 Teclib. All rights reserved.
+*
+*   This file is part of web-mdm-dashboard
+*
+* web-mdm-dashboard is a subproject of Flyve MDM. Flyve MDM is a mobile
+* device management software.
+*
+* Flyve MDM is free software: you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 3
+* of the License, or (at your option) any later version.
+*
+* Flyve MDM is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+* ------------------------------------------------------------------------------
+* @author     Gianfranco Manganiello (gmanganiello@teclib.com)
+* @author     Hector Rondon (hrondon@teclib.com)
+* @copyright  Copyright © 2018 Teclib. All rights reserved.
+* @license    GPLv3 https://www.gnu.org/licenses/gpl-3.0.html
+* @link       https://github.com/flyve-mdm/web-mdm-dashboard
+* @link       http://flyve.org/web-mdm-dashboard
+* @link       https://flyve-mdm.com
+* ------------------------------------------------------------------------------
+*/
+
+import getQueryString from '../index.js'
+
+describe('getQueryString', () => {
+  it('should get QueryString', () => {
+    const history = {
+      location: {
+        search: "?x1=23&x2=test"
+      }
+    }
+    expect(getQueryString(history)).toEqual({x1: "23", x2: "test"})
+  })
+})

--- a/src/shared/getQueryString/index.js
+++ b/src/shared/getQueryString/index.js
@@ -1,0 +1,19 @@
+/**
+ * Get queryString of the history
+ * @function getQueryString
+ * @param {object} history
+ * @return {object}
+ */
+export default (history) => {
+    let search = history.location.search.split('&')
+    search[0] = search[0].substring(1)
+    let queryString = {}
+    search.forEach(element => {
+        const query = element.split('=')
+        queryString = {
+            ...queryString,
+            [query[0]]: query[1]
+        }
+    })
+    return queryString
+}

--- a/src/shared/handleMessage/__test__/handleMessage.spec.js
+++ b/src/shared/handleMessage/__test__/handleMessage.spec.js
@@ -68,7 +68,7 @@ describe('handleMessage', () => {
         message: {
           status: 0,
         },
-      }),
+      })
     ).toEqual({
       body: 'No Internet Connection',
       title: 'Error',
@@ -87,7 +87,7 @@ describe('handleMessage', () => {
             ['Error', ''],
           ],
         },
-      }),
+      })
     ).toEqual({
       body: 'error 404',
       title: 'Error',
@@ -105,7 +105,7 @@ describe('handleMessage', () => {
             ['ERROR_SESSION_TOKEN_INVALID', 'session_token seems invalid'],
           ],
         },
-      }),
+      })
     ).toEqual({
       body: 'session_token seems invalid',
       title: 'Error',
@@ -124,7 +124,7 @@ it('should set a 400 error message', () => {
           ['Error', 'error 400'],
         ],
       },
-    }),
+    })
   ).toEqual({
     body: 'error 400',
     title: 'Error',

--- a/src/shared/handleMessage/index.js
+++ b/src/shared/handleMessage/index.js
@@ -52,7 +52,7 @@ function errorRoute(pathname) {
  * @param {string} title of message
  * @returns {string} Get error message
  */
-export default async ({
+export default ({
   type = 'info',
   message,
   title,
@@ -72,10 +72,10 @@ export default async ({
         if (message.data[0][1] === 'session_token seems invalid') {
           logout()
         }
-        try {
-          await glpi.getActiveProfile()
-          history.push(`${errorRoute(history.location.pathname)}?code=401`)
-        } catch (error) {}
+        glpi.getActiveProfile()
+          .then(res => {
+            history.push(`${errorRoute(history.location.pathname)}?code=401`)
+          })
         break
       case (message.status === 404):
         response.body = message.data[0][1] !== '' ? message.data[0][1] : message.statusText

--- a/src/shared/handleMessage/index.js
+++ b/src/shared/handleMessage/index.js
@@ -34,6 +34,17 @@ import logout from '../logout'
 import glpi from '../glpiApi'
 import history from '../history'
 
+function errorRoute(pathname) {
+  const path = pathname.split('/')
+  let route
+  if (path[1] === 'app') {
+    route = `/app/${path[2]}/error`
+  } else {
+    route = `/${path[1]}/error`
+  }
+  return route
+}
+
 /**
  * Add format to error message
  * @param {string} type of message
@@ -63,7 +74,7 @@ export default async ({
         }
         try {
           await glpi.getActiveProfile()
-          history.push('/error?code=401')
+          history.push(`${errorRoute(history.location.pathname)}?code=401`)
         } catch (error) {}
         break
       case (message.status === 404):
@@ -73,7 +84,7 @@ export default async ({
         response.body = message.data[0][1] ? Array.isArray(message.data[1]) ? message.data[1][0].message
           : message.data[0][1] : message.statusText
         if (message.status === 403) {
-          history.push('/error?code=403')
+          history.push(`${errorRoute(history.location.pathname)}?code=403`)
         }
         break
       default:

--- a/src/shared/handleMessage/index.js
+++ b/src/shared/handleMessage/index.js
@@ -31,6 +31,8 @@
 /** import dependencies */
 import I18n from '../../shared/i18n'
 import logout from '../logout'
+import glpi from '../glpiApi'
+import history from '../history'
 
 /**
  * Add format to error message
@@ -39,7 +41,7 @@ import logout from '../logout'
  * @param {string} title of message
  * @returns {string} Get error message
  */
-export default ({
+export default async ({
   type = 'info',
   message,
   title,
@@ -59,6 +61,10 @@ export default ({
         if (message.data[0][1] === 'session_token seems invalid') {
           logout()
         }
+        try {
+          await glpi.getActiveProfile()
+          history.push('/error?code=401')
+        } catch (error) {}
         break
       case (message.status === 404):
         response.body = message.data[0][1] !== '' ? message.data[0][1] : message.statusText
@@ -66,6 +72,9 @@ export default ({
       case (message.status >= 400 && message.status < 500 && message.status !== 401):
         response.body = message.data[0][1] ? Array.isArray(message.data[1]) ? message.data[1][0].message
           : message.data[0][1] : message.statusText
+        if (message.status === 403) {
+          history.push('/error?code=403')
+        }
         break
       default:
         break

--- a/src/shared/i18n/source_file.json
+++ b/src/shared/i18n/source_file.json
@@ -362,6 +362,28 @@
       }
     }
   },
+  "error": {
+    "400": {
+      "title": "Oops! Bad request",
+      "message": "Apparently you are making an erroneous request. Please return to the dashboard."
+    },
+    "401": {
+      "title": "Unauthorized",
+      "message": "The request has not been applied because it lacks valid authentication credentials for the target resource."
+    },
+    "403": {
+      "title": "Action is forbidden",
+      "message": "Apparently you are trying to perform an action not allowed. Please return to the dashboard."
+    },
+    "404": {
+      "title": "Oops! Page not Found.",
+      "message": "We could not find the page you were looking for. Meanwhile, you may return to the dashboard."
+    },
+    "500": {
+      "title": "Oops! Something went wrong.",
+      "message": "We will work on fixing that rigth away. Meanwhile, you may return to the dashboard."
+    }
+  },
   "commons": {
     "overview": "Overview",
     "system": "System information",
@@ -527,7 +549,6 @@
     "setting_flyve_mdm": "Setting of Flyve MDM",
     "about_flyve_mdm": "About of Flyve MDM",
     "package_name": "Package name",
-    "not_found": "Not Found",
     "load_more": "load more data",
     "saving": "Saving",
     "child_entities": "Child entities",


### PR DESCRIPTION
### Changes description

The idea is to create the error pages on the dashboard, this PR start it using Apache redirection to its personalized error document but I need help from the develop team of the dashboard to finish this cause I don't know how to create the error page on React.

If and error occurs the dashboard should show a page with something like these concept mocked screens.

![imagen](https://user-images.githubusercontent.com/1426313/41256149-c2591c34-6d96-11e8-9ea5-59a953bc36cd.png)

![imagen](https://user-images.githubusercontent.com/1426313/41256288-255da02a-6d97-11e8-958c-484dd1c4cf43.png)

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Ref #10 