### PR TITLE
Loading of the help center wrong centered

### DIFF
--- a/src/containers/About/components/HelpCenter/HelpCenterList.js
+++ b/src/containers/About/components/HelpCenter/HelpCenterList.js
@@ -163,7 +163,7 @@ class HelpCenterList extends PureComponent {
     render() {
         return (
             this.state.isLoading ? 
-                <div style={{height: "100%", marginTop: "-80px"}}><Loading message={`${I18n.t('commons.loading')}...`} /></div> : 
+                <Loading message={`${I18n.t('commons.loading')}...`} />: 
                 (   
                     <ContentPane>
                         <h2 style={{ margin: '10px' }}>{I18n.t('about.help_center.title')}</h2>


### PR DESCRIPTION
Signed-off-by: Gianfranco Manganiello <gmanganiello@teclib.com>

### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->
In this PR:
- Center loading component of the help center

![localhost_3000_app_about_help 3](https://user-images.githubusercontent.com/19965590/41382423-1c6106ca-6f3a-11e8-91dc-7e39bfa267b8.png)



### Checklist

Please check if your PR fulfills the following specifications:

- [x] Tests for the changes have been added
- [x] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Close: #883