### PR TITLE
Fix typo for translations

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -16,6 +16,8 @@ labels:
     color: f44336
   - name: build
     color: 795548
+  - name: cherry-pick
+    color: af1c46
   - name: ci
     color: fbca04
   - name: documentation

--- a/src/containers/SignIn/components/UsernameFieldset.js
+++ b/src/containers/SignIn/components/UsernameFieldset.js
@@ -105,7 +105,7 @@ class UsernameFieldset extends PureComponent {
                         <span> {I18n.t('login.username_not_registered')} </span> 
                         {
                             this.state.selfRegistration ?
-                                <Link to={`${publicURL}/signUp`}>{I18n.t('login.create_an_new')}</Link>
+                                <Link to={`${publicURL}/signUp`}>{I18n.t('login.create_a_new')}</Link>
                                 : null
                         }
                     </p>

--- a/src/hoc/withI18NTranslation/i18n/source_file.json
+++ b/src/hoc/withI18NTranslation/i18n/source_file.json
@@ -2,7 +2,7 @@
   "login": {
     "title": "Sign in",
     "username_not_registered": "The username entered is not registered. Try a different account or",
-    "create_an_new": "create an new",
+    "create_a_new": "create a new",
     "use_your_account": "Use your Flyve MDM account",
     "what_is_this": "What's this?",
     "no_account": "No account?",
@@ -39,7 +39,7 @@
     "device_successfully_removed": "Device successfully removed",
     "invitation_successfully_sent": "Invitation successfully sent",
     "data_deleted_successfully": "Data deleted successfully",
-    "unenrollment_device": "Unenrollment_device",
+    "unenrollment_device": "Unenrollment device",
     "devices_successfully_deleted": "Devices successfully deleted",
     "request_sent": "Request sent",
     "ping_sent": "Ping sent",

--- a/src/hoc/withI18NTranslation/i18n/tests/translations.test.js
+++ b/src/hoc/withI18NTranslation/i18n/tests/translations.test.js
@@ -49,7 +49,7 @@ describe('Check if translations are available', () => {
   it('login page should have english translations', () => {
     expect(I18n.t('login.title')).toBe('Sign in')
     expect(I18n.t('login.username_not_registered')).toBe('The username entered is not registered. Try a different account or')
-    expect(I18n.t('login.create_an_new')).toBe('create an new')
+    expect(I18n.t('login.create_a_new')).toBe('create a new')
     expect(I18n.t('login.use_your_account')).toBe('Use your Flyve MDM account')
     expect(I18n.t('login.what_is_this')).toBe('What\'s this?')
     expect(I18n.t('login.no_account')).toBe('No account?')


### PR DESCRIPTION
### Changes description
While reviewing the translations on Transifex I found two typos
<!-- Describe results, user mentions, screenshots, screencast (gif) -->

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [x] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A